### PR TITLE
Centre Bevy window in HTML webpage

### DIFF
--- a/build/web/setup_display.js
+++ b/build/web/setup_display.js
@@ -1,0 +1,17 @@
+// This function runs after the page has loaded.
+// It checks that the <canvas> element has been loaded into the body,
+// and if so it moves the <canvas> into the <div id="wasm_window"> node.
+// The init_display interval them cancelled.
+(() => {
+    const check_interval = 100; // ms
+    let init_display = setInterval(function () {
+        let canvas = document.body.getElementsByTagName("canvas");
+
+        if (canvas.length > 0) {
+            var fragment = document.createDocumentFragment();
+            fragment.appendChild(canvas[0]);
+            document.getElementById("wasm-window").appendChild(fragment);
+            clearInterval(init_display);
+        }
+    }, check_interval);
+})();

--- a/build/web/styles.css
+++ b/build/web/styles.css
@@ -14,3 +14,12 @@ body {
 canvas {
     background-color: white;
 }
+
+.container {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}

--- a/index.html
+++ b/index.html
@@ -1,15 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8"/>
-        <title>Bevy game</title> <!-- ToDo -->
-        <link data-trunk rel="copy-dir" href="assets"/>
-        <link data-trunk rel="copy-dir" href="credits"/>
-        <link data-trunk rel="copy-file" href="build/windows/icon.ico"/>
-        <link rel="icon" href="icon.ico">
-        <link data-trunk rel="inline" href="build/web/styles.css"/>
+        <meta charset="utf-8" />
+        <title>Bevy game</title>
+        <!-- ToDo -->
+        <link data-trunk rel="copy-dir" href="assets" />
+        <link data-trunk rel="copy-dir" href="credits" />
+        <link data-trunk rel="copy-file" href="build/windows/icon.ico" />
+        <link rel="icon" href="icon.ico" />
+        <link data-trunk rel="inline" href="build/web/styles.css" />
     </head>
     <body>
-        <link data-trunk rel="inline" href="build/web/sound.js"/>
+        <link data-trunk rel="inline" href="build/web/sound.js" />
+        <link data-trunk rel="inline" href="build/web/setup_display.js" />
+        <div class="container">
+            <div id="wasm-window">
+                <!-- WASM window will appear here -->
+            </div>
+        </div>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8" />
-        <title>Bevy game</title>
-        <!-- ToDo -->
-        <link data-trunk rel="copy-dir" href="assets" />
-        <link data-trunk rel="copy-dir" href="credits" />
-        <link data-trunk rel="copy-file" href="build/windows/icon.ico" />
-        <link rel="icon" href="icon.ico" />
-        <link data-trunk rel="inline" href="build/web/styles.css" />
+        <meta charset="utf-8"/>
+        <title>Bevy game</title> <!-- ToDo -->
+        <link data-trunk rel="copy-dir" href="assets"/>
+        <link data-trunk rel="copy-dir" href="credits"/>
+        <link data-trunk rel="copy-file" href="build/windows/icon.ico"/>
+        <link rel="icon" href="icon.ico"/>
+        <link data-trunk rel="inline" href="build/web/styles.css"/>
     </head>
     <body>
-        <link data-trunk rel="inline" href="build/web/sound.js" />
-        <link data-trunk rel="inline" href="build/web/setup_display.js" />
+        <link data-trunk rel="inline" href="build/web/sound.js"/>
+        <link data-trunk rel="inline" href="build/web/setup_display.js"/>
         <div class="container">
             <div id="wasm-window">
                 <!-- WASM window will appear here -->


### PR DESCRIPTION
Thanks for the fantastic template! In particular, the GitHub actions are great - I like how you can manually trigger the deployments with a `workflow_dispatch` trigger :)

This is a minor suggestion that should help developers customise the frontend webpage that the WASM window gets embedded within. Currently the Bevy app loads into a `<canvas>` (with no settable `id`) which is injected into the `<body>` - which means you can't place it before loading, and it has no identifier to help you find it afterwards.

This PR adds a script `setup_display.js` which waits for the Bevy `<canvas>` to load, and then moves it into a div with `id="wasm-window"`, which means you can design the web page by styling the `wasm-window` element.

By default the template webpage's `<div id="wasm-window">` is placed within a `<div class="container">` which will centre the game window within the middle of the page:

![Screenshot 2022-07-22 at 17 14 16](https://user-images.githubusercontent.com/9885605/180480841-02ea779a-5baa-415c-88ec-2598c3aef570.png)

It should then be straightforward to further customise the `index.html` page.