### PR TITLE
Make github linter and yaml linter happy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,7 @@ jobs:
         with:
           file: dist/*.wasm
         # Trunk cannot import assets from relative paths (see e.g. https://github.com/thedodd/trunk/issues/395)
-        # On sites like itch.io, we don't know on wich base path the game gets served, so we need to rewrite all links to be relative
+        # On sites like itch.io, we don't know on which base path the game gets served, so we need to rewrite all links to be relative
       - name: Make paths relative
         run: |
           sed -i 's/\/index/.\/index/g' dist/index.html

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-macOS:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
       - name: Get tag
@@ -155,7 +155,7 @@ jobs:
       - name: Install trunk
         uses: jetli/trunk-action@v0.1.0
         with:
-          version: 'latest'
+          version: latest
       - name: Add wasm target
         run: |
           rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
- `runs-on` is supposed to be `macos-latest` (all lowercase)
- My silly yaml linter was upset with the single quotes. I removed them rather than replace them with double quotes since unnecessary quoting isn't the style we're using here.
- Fixed a typo