### PR TITLE
Refactor plugins; Highlight debug-assertions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ opt-level = 3
 
 [profile.dev]
 opt-level = 1
+debug-assertions = true  # false disables all #[cfg(debug_assertions)] annotations
 
 [profile.release]
 lto = true

--- a/src/default/actions.rs
+++ b/src/default/actions.rs
@@ -1,4 +1,4 @@
-use crate::GameState;
+use crate::default::state::GameState;
 use bevy::prelude::*;
 
 pub struct ActionsPlugin;

--- a/src/default/audio.rs
+++ b/src/default/audio.rs
@@ -1,6 +1,6 @@
-use crate::actions::Actions;
-use crate::loading::AudioAssets;
-use crate::GameState;
+use crate::default::actions::Actions;
+use crate::default::loading::AudioAssets;
+use crate::default::state::GameState;
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 

--- a/src/default/loading.rs
+++ b/src/default/loading.rs
@@ -1,4 +1,4 @@
-use crate::GameState;
+use crate::default::state::GameState;
 use bevy::prelude::*;
 use bevy_asset_loader::prelude::*;
 use bevy_kira_audio::AudioSource;

--- a/src/default/menu.rs
+++ b/src/default/menu.rs
@@ -1,5 +1,5 @@
-use crate::loading::FontAssets;
-use crate::GameState;
+use crate::default::loading::FontAssets;
+use crate::default::state::GameState;
 use bevy::prelude::*;
 
 pub struct MenuPlugin;

--- a/src/default/mod.rs
+++ b/src/default/mod.rs
@@ -1,0 +1,9 @@
+mod actions;
+mod audio;
+mod loading;
+mod menu;
+mod player;
+mod window;
+
+pub mod plugins;
+pub mod state;

--- a/src/default/player.rs
+++ b/src/default/player.rs
@@ -1,6 +1,6 @@
-use crate::actions::Actions;
-use crate::loading::TextureAssets;
-use crate::GameState;
+use crate::default::actions::Actions;
+use crate::default::loading::TextureAssets;
+use crate::default::state::GameState;
 use bevy::prelude::*;
 
 pub struct PlayerPlugin;

--- a/src/default/plugins.rs
+++ b/src/default/plugins.rs
@@ -1,0 +1,22 @@
+use bevy::app::{PluginGroup, PluginGroupBuilder};
+use crate::default::loading::LoadingPlugin;
+use crate::default::menu::MenuPlugin;
+use crate::default::actions::ActionsPlugin;
+use crate::default::audio::InternalAudioPlugin;
+use crate::default::player::PlayerPlugin;
+use crate::default::window::StarterWindowPlugin;
+
+pub struct StarterPlugins;
+
+impl PluginGroup for StarterPlugins {
+    fn build(&mut self, group: &mut PluginGroupBuilder) {
+        group
+            .add(StarterWindowPlugin)
+            .add(LoadingPlugin)
+            .add(MenuPlugin)
+            .add(ActionsPlugin)
+            .add(InternalAudioPlugin)
+            .add(PlayerPlugin);
+    }
+}
+

--- a/src/default/state.rs
+++ b/src/default/state.rs
@@ -1,0 +1,12 @@
+// This example game uses States to separate logic
+// See https://bevy-cheatbook.github.io/programming/states.html
+// Or https://github.com/bevyengine/bevy/blob/main/examples/ecs/state.rs
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+pub enum GameState {
+    // During the loading State the LoadingPlugin will load our assets
+    Loading,
+    // During this State the actual game logic is executed
+    Playing,
+    // Here the menu is drawn and waiting for player interaction
+    Menu,
+}

--- a/src/default/window.rs
+++ b/src/default/window.rs
@@ -1,0 +1,41 @@
+use bevy::app::{Plugin, App};
+use bevy::core_pipeline::clear_color::ClearColor;
+use bevy::window::{WindowDescriptor, WindowId};
+use bevy::render::view::Msaa;
+use bevy::render::color::Color;
+use bevy::ecs::system::NonSend;
+use bevy::winit::WinitWindows;
+use std::io::Cursor;
+use winit::window::Icon;
+
+/// This will create the default window for you.
+pub struct StarterWindowPlugin;
+
+impl Plugin for StarterWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .insert_resource(Msaa { samples: 1 })
+            .insert_resource(ClearColor(Color::rgb(0.4, 0.4, 0.4)))
+            .insert_resource(WindowDescriptor {
+                width: 800.,
+                height: 600.,
+                title: "Bevy game".to_string(), // ToDo
+                canvas: Some("#bevy".to_owned()),
+                ..Default::default()
+            })
+            .add_startup_system(set_window_icon);
+    }
+}
+
+/// Set the icon on windows and X11
+fn set_window_icon(windows: NonSend<WinitWindows>) {
+    let primary = windows.get_window(WindowId::primary()).unwrap();
+    let icon_buf = Cursor::new(include_bytes!("../../assets/textures/app_icon.png"));
+    if let Ok(image) = image::load(icon_buf, image::ImageFormat::Png) {
+        let image = image.into_rgba8();
+        let (width, height) = image.dimensions();
+        let rgba = image.into_raw();
+        let icon = Icon::from_rgba(rgba, width, height).unwrap();
+        primary.set_window_icon(Some(icon));
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,43 +1,18 @@
-mod actions;
-mod audio;
-mod loading;
-mod menu;
-mod player;
-
-use crate::actions::ActionsPlugin;
-use crate::audio::InternalAudioPlugin;
-use crate::loading::LoadingPlugin;
-use crate::menu::MenuPlugin;
-use crate::player::PlayerPlugin;
+mod default;
 
 use bevy::app::App;
 #[cfg(debug_assertions)]
 use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::prelude::*;
-
-// This example game uses States to separate logic
-// See https://bevy-cheatbook.github.io/programming/states.html
-// Or https://github.com/bevyengine/bevy/blob/main/examples/ecs/state.rs
-#[derive(Clone, Eq, PartialEq, Debug, Hash)]
-enum GameState {
-    // During the loading State the LoadingPlugin will load our assets
-    Loading,
-    // During this State the actual game logic is executed
-    Playing,
-    // Here the menu is drawn and waiting for player interaction
-    Menu,
-}
+use crate::default::plugins::StarterPlugins;
+use crate::default::state::GameState;
 
 pub struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_state(GameState::Loading)
-            .add_plugin(LoadingPlugin)
-            .add_plugin(MenuPlugin)
-            .add_plugin(ActionsPlugin)
-            .add_plugin(InternalAudioPlugin)
-            .add_plugin(PlayerPlugin);
+            .add_plugins(StarterPlugins);
 
         #[cfg(debug_assertions)]
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,13 @@
 // disable console on windows for release builds
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use bevy::prelude::{App, ClearColor, Color, Msaa, NonSend, WindowDescriptor};
-use bevy::window::WindowId;
-use bevy::winit::WinitWindows;
+use bevy::prelude::App;
 use bevy::DefaultPlugins;
 use bevy_game::GamePlugin;
-use std::io::Cursor;
-use winit::window::Icon;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 1 })
-        .insert_resource(ClearColor(Color::rgb(0.4, 0.4, 0.4)))
-        .insert_resource(WindowDescriptor {
-            width: 800.,
-            height: 600.,
-            title: "Bevy game".to_string(), // ToDo
-            canvas: Some("#bevy".to_owned()),
-            ..Default::default()
-        })
         .add_plugins(DefaultPlugins)
         .add_plugin(GamePlugin)
-        .add_startup_system(set_window_icon)
         .run();
-}
-
-// Sets the icon on windows and X11
-fn set_window_icon(windows: NonSend<WinitWindows>) {
-    let primary = windows.get_window(WindowId::primary()).unwrap();
-    let icon_buf = Cursor::new(include_bytes!("../assets/textures/app_icon.png"));
-    if let Ok(image) = image::load(icon_buf, image::ImageFormat::Png) {
-        let image = image.into_rgba8();
-        let (width, height) = image.dimensions();
-        let rgba = image.into_raw();
-        let icon = Icon::from_rgba(rgba, width, height).unwrap();
-        primary.set_window_icon(Some(icon));
-    };
 }


### PR DESCRIPTION
Hi there,

I found it more useful to isolate all of the starter, default plugins, logic, etc into its own "default" folder, so that I can better decouple the `bevy_game` starter template from the additional things I want to add to the project.  

Also, incidentally it shows users of this template how they can organize their own code as well.

Lastly, I added a `debug-assertions` line in the Cargo.toml so that it's more obvious to users of this template how they can disable the default "frame diagnostic" logging that would otherwise normally flood `stdout` whenever they run the application.

edit - Also, by using public and private, it sets a good example for the users of this template to follow, so that their code is more organized and not just 5_000 lines in a single file.