### PR TITLE
Improve background stripes

### DIFF
--- a/build/web/styles.css
+++ b/build/web/styles.css
@@ -3,16 +3,13 @@ body, html {
 }
 
 body {
-    background: linear-gradient(
-            135deg,
-            white 0%,
-            white 49%,
-            black 49%,
-            black 51%,
-            white 51%,
-            white 100%
-    ) repeat;
-    background-size: 20px 20px;
+    background: repeating-linear-gradient(
+        135deg,
+        black 0,
+        black 2px,
+        white 2px,
+        white 20px
+    );
     margin: 0;
 }
 


### PR DESCRIPTION
For the web version, if you zoom in enough, the background stripes are a little cut off. This commit solves that problem and thickens the lines a bit (so it doesn’t look too thin, displaying badly on retina monitors)