### PR TITLE
RFC: Cargo generate example.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,13 +5,13 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
-# ToDo: adapt names
 env:
-  # heads-up: this value is used as a pattern in an sed command as a workaround for a trunk issue
+  # heads-up: this value is used as a pattern in a sed command as a workaround for a trunk issue
   #   if you use special characters, take a look at the 'Make paths relative' step in the 'build-web' job
-  GAME_EXECUTABLE_NAME: bevy_game
-  GAME_OSX_APP_NAME: BevyGame
+  GAME_EXECUTABLE_NAME: {{project-name}}
+  GAME_OSX_APP_NAME: {{macos_pkg}}
 
+{% raw %}
 jobs:
   build-macOS:
     runs-on: macos-latest
@@ -185,3 +185,4 @@ jobs:
           asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_web.zip
           tag: ${{ github.ref }}
           overwrite: true
+{% endraw %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "bevy_game" # ToDo
+name = "{{project-name}}"
 version = "0.1.0"
 publish = false
-authors = ["Niklas Eicker <git@nikl.me>"] # ToDo: you are the author ;)
+authors = ["{{authors}}"]
 edition = "2021"
 exclude = ["dist", "build", "assets", "credits"]
 
@@ -33,3 +33,4 @@ image = { version = "0.24", default-features = false }
 
 [build-dependencies]
 embed-resource = "1.4"
+

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ _Since Bevy is in heavy development, there regularly are unpublished new feature
     * WARNING: if you work in a private repository, please be aware that macOS and Windows runners cost more build minutes. You might want to consider running the workflow less often or removing some builds from it. **For public repositories the builds are free!**
 
 # How to use this template?
- 1. Click "Use this template" on the repository's page
- 2. Look for `ToDo` to use your own game name everywhere
- 3. [Update the icons as described below](#updating-the-icons)
- 4. Start coding :tada:
+ 1. Generate your game using [cargo generate](https://crates.io/crates/cargo-generate/0.10.3)
+
+    [//]: # (TODO: Correct repository path)
+    ```commandline
+    cargo generate --git https://github.com/Stedders/bevy_game_template --branch feature/convert-to-cargo-generate
+    ```
+ 2. [Update the icons as described below](#updating-the-icons)
+ 3. Start coding :tada:
     * Start the native app: `cargo run`
     * Start the web build: `trunk serve`
        * requires [trunk]: `cargo install --locked trunk`

--- a/build/macos/src/Game.app/Contents/Info.plist
+++ b/build/macos/src/Game.app/Contents/Info.plist
@@ -5,17 +5,17 @@
         <key>CFBundleDevelopmentRegion</key>
         <string>en</string>
         <key>CFBundleDisplayName</key>
-        <string>BevyGame</string> <!-- ToDo: this should be the same as your OSX app name in the release flow -->
+        <string>{{macos_pkg}}</string>
         <key>CFBundleExecutable</key>
-        <string>bevy_game</string> <!-- ToDo: this should be the same as your executable name in the release flow -->
+        <string>{{project-name}}</string>
         <key>CFBundleIconFile</key>
         <string>AppIcon.icns</string>
         <key>CFBundleIdentifier</key>
-        <string>your.domain.bevy-game</string> <!-- ToDo -->
+        <string>{{domain}}.{{project-name}}</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
         <key>CFBundleName</key>
-        <string>Bevy Game</string> <!-- ToDo -->
+        <string>{{game_name}}</string>
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,6 @@
+[hooks]
+pre = ["pre-script.rhai"]
+
+[placeholders]
+domain = { type = "string", prompt = "What is your domain (for MacOS builds)", default = "your.domain", regex = ".+(\\..+)*" }
+

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
-        <title>Bevy game</title> <!-- ToDo -->
+        <title>{{game_name}}</title>
         <link data-trunk rel="copy-dir" href="assets"/>
         <link data-trunk rel="copy-dir" href="credits"/>
         <link data-trunk rel="copy-file" href="build/windows/icon.ico"/>

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -13,5 +13,10 @@ for (component, count) in project_components {
 }
 let macos_pkg = game_name;
 macos_pkg.replace(" ", "");
+
+let project_package = project_name;
+project_package.replace("-", "_");
+
 variable::set("game_name", game_name);
 variable::set("macos_pkg", macos_pkg);
+variable::set("project_package", project_package);

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -1,0 +1,17 @@
+// Pre-generation script, runs after variables are assigned but before generation
+// Break the project name out into its components and create game_name and macos_pkg variables
+let project_name = variable::get("project-name");
+let project_components = project_name.split("-");
+let game_name = "";
+
+for (component, count) in project_components {
+    component[0] = component[0].to_upper();
+    game_name += component;
+    if count + 1 < project_components.len {
+        game_name += " ";
+    }
+}
+let macos_pkg = game_name;
+macos_pkg.replace(" ", "");
+variable::set("game_name", game_name);
+variable::set("macos_pkg", macos_pkg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use bevy::window::WindowId;
 use bevy::winit::WinitWindows;
 use bevy::DefaultPlugins;
-use bevy_game::GamePlugin;
+use {{project_package}}::GamePlugin;
 use std::io::Cursor;
 use winit::window::Icon;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
             window: WindowDescriptor {
                 width: 800.,
                 height: 600.,
-                title: "Bevy game".to_string(), // ToDo
+                title: "{{game_name}}".to_string(),
                 canvas: Some("#bevy".to_owned()),
                 ..Default::default()
             },


### PR DESCRIPTION
Convert template into a cargo generate template.

You can then use cargo generate to stamp out a project, similar to cookiecutter. This approach removes the need to search for "TODO" as all the values are derived from the prohject name. In addition it removes the risk of typos/inconsistencies between values.

Let me know your thoughts.