### PR TITLE
Fix asset loading in debug launch config on Linux

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,8 @@
             },
             "linux": {
                 "env": {
+                    // platform-specific launch config overwrites (rather than merges with) existing config, so need to specify CARGO_MANIFEST_DIR again
+                    "CARGO_MANIFEST_DIR": "${workspaceFolder}",
                     "LD_LIBRARY_PATH": "${env:LD_LIBRARY_PATH}:${workspaceFolder}/target/debug:${env:HOME}/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib:${env:HOME}/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib"
                 }
             }


### PR DESCRIPTION
### Problem
When running the `Debug` launch configuration in vscode on Linux, the assets are not loaded, so the menu button is not visible. The `Quick Launch` launch configuration works fine.

### Diagnosis
1. Bevy logs show lines like `2023-08-10T11:39:58.234289Z  WARN bevy_asset::asset_server: encountered an error while reading an asset: path not found: /home/foo/src/bevy_game/target/debug/assets/fonts/FiraSans-Bold.ttf` , indicating that Bevy isn't detecting the root folder correctly.
2. The Debug launch configuration is setting `CARGO_MANIFEST_DIR` as (one of the variables that) Bevy expects to see, however `cat  "/proc/$(pgrep bevy_game)/environ" | tr '\0' '\n' | grep CARGO` returns no results, indicating that the environment variable isn't actually getting set.
3. Vscode [docs say](https://code.visualstudio.com/docs/editor/debugging#_platformspecific-properties) `Properties defined in an operating system specific scope override properties defined in the global scope.` so the `.linux.env` setting is overriding the `.env` setting (rather than being merged with it, as one might reasonably expect).

### Fix
Duplicate `CARGO_MANIFEST_DIR` into `.linux.env`.

### Other notes
* any particular reason you picked `CARGO_MANIFEST_DIR` over `BEVY_ASSET_ROOT`?
* the `Debug unit tests` config sets `LD_LIBRARY_PATH` to the same value for all platforms rather than having a Linux specific override, which on the one hand seems like a mistake (the value is decidedly Linux-specific), but on the other hand is harmless (the envvar has no meaning on non-Linux platforms) - so a reasonable alternative fix is to just do the same thing for the `Debug` launch config.