### PR TITLE
Add missing ToDo in mobile/src/lib.rs

### DIFF
--- a/mobile/src/lib.rs
+++ b/mobile/src/lib.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy::window::WindowMode;
-use bevy_game::GamePlugin;
+use bevy_game::GamePlugin; // ToDo: Replace bevy_game with your new crate name.
 
 #[bevy_main]
 fn main() {


### PR DESCRIPTION
Found a missing ToDo for a place where `bevy_game` needs to be replaced with your own app crate name.