### PR TITLE
Minimal support for sdk

### DIFF
--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -27,7 +27,7 @@ resources = "../build/android/res"
 build_targets = ["aarch64-linux-android"]
 
 [package.metadata.android.sdk]
-target_sdk_version = 31
+target_sdk_version = 33
 
 [package.metadata.android.application]
 icon = "@mipmap/icon"


### PR DESCRIPTION
As of August, the minimum [API support for Google Play](https://developer.android.com/google/play/requirements/target-sdk) is 33. This change makes it easier to review when submitting the app to the store.