### PR TITLE
Set viewport meta in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
         <title>Bevy game</title> <!-- ToDo -->
         <link data-trunk rel="copy-dir" href="assets"/>
         <link data-trunk rel="copy-dir" href="credits"/>


### PR DESCRIPTION
Mobile browsers default to a width of ~980px to support desktop sites. Bevy then applies the device's scaling factor (usually around 2-3) to end up with a canvas of >2k width and >4k height (since most phones are ~2:1 tall). 

Viewport meta seems to be the standard way to indicate that a web page can handle scaling for mobile.

The fields do the following:

- `width=device-width` sets the page width to that of the device, with scaling factor applied (so on a 1080px wide physical device it would be ~450px).
- `initial-scale=1` ensures the width is updated when the device is rotated.
- `user-scalable=no` prevents the default pinch-to-zoom behavior, which is not usually recommended, but makes sense for a game.