### PR TITLE
Fix 3d camera on ios simulator

### DIFF
--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -18,6 +18,7 @@ bevy = { version = "0.14", default-features = false }
 version = "0.15"
 features = ["oboe-shared-stdcxx"]
 
+# See https://github.com/bevyengine/bevy/pull/12052
 [target.aarch64-apple-ios-sim.dependencies]
 bevy = { version = "0.14", default-features = false, features = [
     "ios_simulator",

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -18,6 +18,11 @@ bevy = { version = "0.14", default-features = false }
 version = "0.15"
 features = ["oboe-shared-stdcxx"]
 
+[target.aarch64-apple-ios-sim.dependencies]
+bevy = { version = "0.14", default-features = false, features = [
+    "ios_simulator",
+] }
+
 [package.metadata.android]
 package = "me.nikl.bevygame"  # ToDo
 apk_name = "BevyGame"  # ToDo same as GAME_OSX_APP_NAME in release workflow


### PR DESCRIPTION
Fixes #118 

Tested by modifying the template to include (roughly) Bevy's `3d_scene` example and running `make run`.

Observed the shader error without this PR, and a working scene with.

<img width="889" alt="image" src="https://github.com/user-attachments/assets/987c8f5c-61c2-49ff-9444-de2371336e0d">


